### PR TITLE
[WIP] Add default nginx container for services

### DIFF
--- a/services/main.tf
+++ b/services/main.tf
@@ -44,6 +44,8 @@ module "task" {
   service_vars = [
     "{ \"name\" : \"INFRA_BUCKET\", \"value\" : \"${var.infra_bucket}\" }",
     "{ \"name\" : \"CONFIG_KEY\", \"value\" : \"${var.config_key}\" }",
+    "{ \"name\" : \"HTTPS_DOMAIN\", \"value\" : \"${var.https_domain}\" }",
+    "{ \"name\" : \"APP_PORT\", \"value\" : \"${var.secondary_container_port}\" }",
   ]
 
   extra_vars = "${var.extra_vars}"

--- a/services_default_nginx/Dockerfile
+++ b/services_default_nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx
+
+COPY nginx.conf.template /etc/nginx/nginx.conf.template
+
+CMD /bin/bash -c "envsubst '\$HTTPS_DOMAIN \$APP_PORT' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"

--- a/services_default_nginx/README.md
+++ b/services_default_nginx/README.md
@@ -1,0 +1,10 @@
+#Default NGINX image for ECS Services
+
+This container image is intended to work with the services module provided in this repo.
+
+By default this container redirects HTTPS -> HTTP.
+
+This container needs to be started with two environment variables:
+
+- `HTTPS_DOMAIN`: The domain to redirect HTTPS requests to
+- `APP_PORT`: The application port to redirect to.

--- a/services_default_nginx/nginx.conf.template
+++ b/services_default_nginx/nginx.conf.template
@@ -1,0 +1,37 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+  server {
+    listen 9000;
+    server_tokens off;
+
+    # Ensure that requests sent over HTTP are redirected to HTTPS.
+    # http://scottwb.com/blog/2013/10/28/always-on-https-with-nginx-behind-an-elb/
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_next_upstream error;
+
+    if ($http_x_forwarded_proto != "https") {
+      set $https_redirect "1";
+    }
+
+    if ($http_user_agent != "ELB-HealthChecker/2.0") {
+      set $https_redirect "${https_redirect}1";
+    }
+
+    if ($https_redirect = "11") {
+      rewrite ^(.*)$ https://${HTTPS_DOMAIN}$1 permanent;
+    }
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
+
+    location ~ ^/[^/]+/.* {
+      rewrite ^/[^/]+/(.*) /$1 break;
+      proxy_pass http://app:${APP_PORT};
+    }
+  }
+}


### PR DESCRIPTION
In order to make the process of setting up a service faster this PR adds a default nginx container hosted on docker hub that does not require http domain and application port to be hard coded.