### PR TITLE
Add ability to register an ALB with the Docker ports on launch_config…

### DIFF
--- a/ecs_asg/ecs_asg_launch_config/security_groups.tf
+++ b/ecs_asg/ecs_asg_launch_config/security_groups.tf
@@ -20,6 +20,7 @@ resource "aws_security_group" "instance_sg" {
 
     security_groups = [
       "${aws_security_group.https.id}",
+      "${var.alb_security_groups}",
     ]
   }
 

--- a/ecs_asg/ecs_asg_launch_config/variables.tf
+++ b/ecs_asg/ecs_asg_launch_config/variables.tf
@@ -48,3 +48,9 @@ variable "ebs_size" {}
 variable "ebs_volume_type" {}
 
 variable "ebs_iops" {}
+
+variable "alb_security_groups" {
+  description = "ALB security group to allow docker port access for healthchecks"
+  type        = "list"
+  default     = []
+}

--- a/ecs_asg/main.tf
+++ b/ecs_asg/main.tf
@@ -31,4 +31,5 @@ module "launch_config" {
   public_ip             = "${var.public_ip}"
   ebs_volume_type       = "${var.ebs_volume_type}"
   ebs_iops              = "${var.ebs_iops}"
+  alb_security_groups   = "${var.alb_security_groups}"
 }

--- a/ecs_asg/variables.tf
+++ b/ecs_asg/variables.tf
@@ -91,3 +91,9 @@ variable "ebs_volume_type" {
 variable "ebs_iops" {
   default = ""
 }
+
+variable "alb_security_groups" {
+  description = "ALB security group to allow docker port access for healthchecks"
+  type        = "list"
+  default     = []
+}

--- a/lambda/variables.tf
+++ b/lambda/variables.tf
@@ -4,7 +4,7 @@ variable "name" {
 
 variable "module_name" {
   description = "Name of the python module where the handler function lives"
-  default = ""
+  default     = ""
 }
 
 variable "description" {


### PR DESCRIPTION
… via security groups to healthcheck.

Allows us to allow an ALB to run healthchecks on the instances it get's registered to.

It wouldn't be sustainable to have the ALB register every security group created here with itself from a maintenance POV, but you can also only have 5 SGs / ALB. 